### PR TITLE
Accommodate RcppArmadillo 14.4.0-0

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -1963,7 +1963,7 @@ double logLike_ARXmdl(arma::vec theta, List mdl){
   arma::mat repmu(Tsize, phi.n_elem,arma::fill::ones);
   arma::mat repzb(Tsize, 1,arma::fill::ones);
   arma::vec resid = (y - mu) - (x-(mu*repmu))*phi - (z-(repzb*zbar))*betaZ;
-  logLike = as_scalar(sum(log((1/sqrt(2*pi*sigma))*exp(-pow(resid,2)/(2*sigma)))));
+  logLike = arma::as_scalar(sum(log((1/sqrt(2*pi*sigma))*exp(-pow(resid,2)/(2*sigma)))));
   return(logLike);
 }
 // ==============================================================================


### PR DESCRIPTION
Dear MSTest team,

Armadillo 14.4.0 has been released today, and Conrad and I had prepared this with the usual suite of reverse-dependency checks. A handful of packages, yours included, requires a minimal patch to compile as e.g. as_scalar now requires proper namespace scope.

This pull request is a one-line change after which the package installs fine as expected.

You can test it with the (GitHub and r-universe only) version 14.4.0-0 of RcppArmadillo which you can install via

```r
install.packages('RcppArmadillo', 
    repos = c('https://rcppcore.r-universe.dev',  'https://cran.r-project.org'))
```

We would like to bring the updated version to CRAN within three to four weeks so an update of your package would be greatly appreciated.  Please let us know if you have any questions; the issue is being tracked at https://github.com/RcppCore/RcppArmadillo/issues/462

Thanks!